### PR TITLE
Handle tailing of non-existent app

### DIFF
--- a/ltc/cli_app_factory/cli_app_factory.go
+++ b/ltc/cli_app_factory/cli_app_factory.go
@@ -121,7 +121,7 @@ func cliCommands(timeoutStr, ltcConfigRoot string, exitHandler exit_handler.Exit
 		appRunnerCommandFactory.MakeCreateAppCommand(),
 		logsCommandFactory.MakeDebugLogsCommand(),
 		appExaminerCommandFactory.MakeListAppCommand(),
-		logsCommandFactory.MakeLogsCommand(),
+		logsCommandFactory.MakeLogsCommand( appExaminer ),
 		appRunnerCommandFactory.MakeRemoveAppCommand(),
 		appRunnerCommandFactory.MakeScaleAppCommand(),
 		appExaminerCommandFactory.MakeStatusCommand(),

--- a/ltc/logs/command_factory/logs_command_factory.go
+++ b/ltc/logs/command_factory/logs_command_factory.go
@@ -1,6 +1,7 @@
 package command_factory
 
 import (
+	"github.com/cloudfoundry-incubator/lattice/ltc/app_examiner"
 	"github.com/cloudfoundry-incubator/lattice/ltc/exit_handler"
 	"github.com/cloudfoundry-incubator/lattice/ltc/logs/console_tailed_logs_outputter"
 	"github.com/cloudfoundry-incubator/lattice/ltc/logs/reserved_app_ids"
@@ -12,6 +13,7 @@ type logsCommandFactory struct {
 	ui                  terminal.UI
 	tailedLogsOutputter console_tailed_logs_outputter.TailedLogsOutputter
 	exitHandler         exit_handler.ExitHandler
+	app                 app_examiner.AppExaminer
 }
 
 func NewLogsCommandFactory(ui terminal.UI, tailedLogsOutputter console_tailed_logs_outputter.TailedLogsOutputter, exitHandler exit_handler.ExitHandler) *logsCommandFactory {
@@ -22,7 +24,7 @@ func NewLogsCommandFactory(ui terminal.UI, tailedLogsOutputter console_tailed_lo
 	}
 }
 
-func (factory *logsCommandFactory) MakeLogsCommand() cli.Command {
+func (factory *logsCommandFactory) MakeLogsCommand(app app_examiner.AppExaminer) cli.Command {
 	var logsCommand = cli.Command{
 		Name:        "logs",
 		ShortName:   "lo",
@@ -31,6 +33,8 @@ func (factory *logsCommandFactory) MakeLogsCommand() cli.Command {
 		Action:      factory.tailLogs,
 		Flags:       []cli.Flag{},
 	}
+
+	factory.app = app
 
 	return logsCommand
 }
@@ -50,6 +54,14 @@ func (factory *logsCommandFactory) tailLogs(context *cli.Context) {
 
 	if appGuid == "" {
 		factory.ui.IncorrectUsage("")
+		return
+	}
+
+	// Check if there is really such app before we start waiting for its logs.
+	_, err := factory.app.AppStatus(appGuid)
+
+	if err != nil {
+		factory.ui.Say(err.Error())
 		return
 	}
 

--- a/ltc/logs/command_factory/logs_command_factory_test.go
+++ b/ltc/logs/command_factory/logs_command_factory_test.go
@@ -1,12 +1,15 @@
 package command_factory_test
 
 import (
+	"errors"
 	"os"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
 
+	"github.com/cloudfoundry-incubator/lattice/ltc/app_examiner"
+	"github.com/cloudfoundry-incubator/lattice/ltc/app_examiner/fake_app_examiner"
 	"github.com/cloudfoundry-incubator/lattice/ltc/exit_handler"
 	"github.com/cloudfoundry-incubator/lattice/ltc/exit_handler/fake_exit_handler"
 	"github.com/cloudfoundry-incubator/lattice/ltc/logs/command_factory"
@@ -37,10 +40,12 @@ var _ = Describe("CommandFactory", func() {
 	Describe("LogsCommand", func() {
 
 		var logsCommand cli.Command
+		var appExaminer *fake_app_examiner.FakeAppExaminer
 
 		BeforeEach(func() {
 			commandFactory := command_factory.NewLogsCommandFactory(terminalUI, fakeTailedLogsOutputter, exitHandler)
-			logsCommand = commandFactory.MakeLogsCommand()
+			appExaminer = &fake_app_examiner.FakeAppExaminer{}
+			logsCommand = commandFactory.MakeLogsCommand(appExaminer)
 		})
 
 		It("tails logs", func() {
@@ -58,6 +63,17 @@ var _ = Describe("CommandFactory", func() {
 			test_helpers.ExecuteCommandWithArgs(logsCommand, []string{})
 
 			Expect(outputBuffer).To(test_helpers.Say("Incorrect Usage"))
+			Expect(fakeTailedLogsOutputter.OutputTailedLogsCallCount()).To(Equal(0))
+		})
+
+		It("handles non existent appguids", func() {
+			args := []string{
+				"non_existent_app",
+			}
+			appExaminer.AppStatusReturns(app_examiner.AppInfo{}, errors.New("App not found."))
+			test_helpers.ExecuteCommandWithArgs(logsCommand, args)
+
+			Expect(outputBuffer).To(test_helpers.Say("App not found"))
 			Expect(fakeTailedLogsOutputter.OutputTailedLogsCallCount()).To(Equal(0))
 		})
 	})


### PR DESCRIPTION
Previously 

```
$ltc logs non_existent_app
```

will hang indefinitely now it reports an error.

```
$ltc logs non_existent_app
App not found.
```
