### PR TITLE
Handle tailing of non-existent app

### DIFF
--- a/ltc/logs/command_factory/logs_command_factory.go
+++ b/ltc/logs/command_factory/logs_command_factory.go
@@ -60,9 +60,9 @@ func (factory *logsCommandFactory) tailLogs(context *cli.Context) {
 	// Check if there is really such app before we start waiting for its logs.
 	_, err := factory.app.AppStatus(appGuid)
 
-	if err != nil {
-		factory.ui.Say(err.Error())
-		return
+	if err != nil && err.Error() == "App not found." {
+		factory.ui.SayLine("Application " + appGuid + " not found.")
+		factory.ui.SayLine("Tailing logs and waiting for " + appGuid + " to appear...")
 	}
 
 	factory.tailedLogsOutputter.OutputTailedLogs(appGuid)

--- a/ltc/logs/command_factory/logs_command_factory_test.go
+++ b/ltc/logs/command_factory/logs_command_factory_test.go
@@ -66,15 +66,16 @@ var _ = Describe("CommandFactory", func() {
 			Expect(fakeTailedLogsOutputter.OutputTailedLogsCallCount()).To(Equal(0))
 		})
 
-		It("handles non existent appguids", func() {
+		It("handles non existent application", func() {
 			args := []string{
 				"non_existent_app",
 			}
-			appExaminer.AppStatusReturns(app_examiner.AppInfo{}, errors.New("App not found."))
-			test_helpers.ExecuteCommandWithArgs(logsCommand, args)
+			appExaminer.AppStatusReturns(app_examiner.AppInfo{}, errors.New("App not found.")) //The app examiner only returns App not found
+			test_helpers.AsyncExecuteCommandWithArgs(logsCommand, args)
 
-			Expect(outputBuffer).To(test_helpers.Say("App not found"))
-			Expect(fakeTailedLogsOutputter.OutputTailedLogsCallCount()).To(Equal(0))
+			Eventually(fakeTailedLogsOutputter.OutputTailedLogsCallCount).Should(Equal(1))
+			Expect(outputBuffer).To(test_helpers.Say("Application non_existent_app not found.\nTailing logs and waiting for non_existent_app to appear..."))
+
 		})
 	})
 


### PR DESCRIPTION
```
$ltc logs not_yet_app
```

Used to wait indefinitely, now it prints additional message before continuing to wait.

```
$date
Wed Mar 25 19:09:39 EDT 2015
$ltc logs not_yet_app
Application not_yet_app not found.
Tailing logs and waiting for not_yet_app to appear...
25 Mar 19:10 [APP|0] Creating container
```
