### PR TITLE
fix tee2metron unit tests from leaving orphan process running

### DIFF
--- a/tee2metron/main.go
+++ b/tee2metron/main.go
@@ -78,5 +78,10 @@ func main() {
 		os.Exit(3)
 	}
 
-	cmd.Wait()
+	// if the child is killed abnormally we would know
+	err = cmd.Wait()
+	if err != nil {
+		fmt.Println(args[0], ":", err)
+		os.Exit(3)
+	}
 }


### PR DESCRIPTION
We found the same thing as explained story below happening in our environment

https://www.pivotaltracker.com/n/projects/1183596/stories/90964260

Also added a test case for permission issues also.    

```
$ps -ef | grep chatty
$ginkgo -r tee2metron/
Running Suite: Tee2metron Suite
===============================
Random Seed: 1428032392
Will run 6 of 6 specs

••••••
Ran 6 of 6 Specs in 1.122 seconds
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 0 Skipped PASS

Ginkgo ran 1 suite in 1.829774919s
Test Suite Passed
$ps -ef | grep chatty
```

previously it used to leave a couple of process running like below

```
$ps -ef | grep chatty
cf       118990      1  0 18:58 pts/6    00:00:01 /tmp/gexec_artifacts021681306/g314086193/tee2metron -dropsondeDestination=127.0.0.1:34275 -sourceInstance=lattice-cell-123 /tmp/gexec_artifacts021681306/g274702556/chatty_process chattyArg1 chattyArg2 -chattyFlag
cf       118993 118990  0 18:58 pts/6    00:00:00 /tmp/gexec_artifacts021681306/g274702556/chatty_process chattyArg1 chattyArg2 -chattyFlag

```
