### PR TITLE
ltc command flags should have short versions

### DIFF
--- a/ltc/app_runner/command_factory/app_runner_command_factory.go
+++ b/ltc/app_runner/command_factory/app_runner_command_factory.go
@@ -92,7 +92,7 @@ func (factory *AppRunnerCommandFactory) MakeCreateAppCommand() cli.Command {
 			Value: &cli.StringSlice{},
 		},
 		cli.IntFlag{
-			Name:  "cpu-weight",
+			Name:  "cpu-weight, c",
 			Usage: "Relative CPU weight for the container (valid values: 1-100)",
 			Value: 100,
 		},
@@ -111,16 +111,16 @@ func (factory *AppRunnerCommandFactory) MakeCreateAppCommand() cli.Command {
 			Usage: "Ports to expose on the container",
 		},
 		cli.IntFlag{
-			Name:  "monitored-port",
+			Name:  "monitored-port, M",
 			Usage: "Selects which port is used to healthcheck the app. Required for multiple exposed ports",
 		},
 		cli.StringFlag{
-			Name: "routes",
+			Name: "routes, R",
 			Usage: "Route mappings to exposed ports as follows:\n\t\t" +
 				"--routes=80:web,8080:api will route web to 80 and api to 8080",
 		},
 		cli.IntFlag{
-			Name:  "instances",
+			Name:  "instances, i",
 			Usage: "Number of application instances to spawn on launch",
 			Value: 1,
 		},
@@ -133,7 +133,7 @@ func (factory *AppRunnerCommandFactory) MakeCreateAppCommand() cli.Command {
 			Usage: "Registers no routes for the app",
 		},
 		cli.DurationFlag{
-			Name:  "timeout",
+			Name:  "timeout, t",
 			Usage: "Polling timeout for app to start",
 			Value: DefaultPollingTimeout,
 		},
@@ -184,7 +184,7 @@ func (factory *AppRunnerCommandFactory) MakeCreateLrpCommand() cli.Command {
 func (factory *AppRunnerCommandFactory) MakeScaleAppCommand() cli.Command {
 	var scaleFlags = []cli.Flag{
 		cli.DurationFlag{
-			Name:  "timeout",
+			Name:  "timeout, t",
 			Usage: "Polling timeout for app to scale",
 			Value: DefaultPollingTimeout,
 		},

--- a/ltc/logs/command_factory/logs_command_factory.go
+++ b/ltc/logs/command_factory/logs_command_factory.go
@@ -60,7 +60,7 @@ func (factory *logsCommandFactory) tailLogs(context *cli.Context) {
 	appGuid := context.Args().First()
 
 	if appGuid == "" {
-		factory.ui.SayIncorrectUsage("")
+		factory.ui.SayIncorrectUsage("APP_NAME required")
 		return
 	}
 


### PR DESCRIPTION
Now ltc commnad will show short versions for the command flags.
http://rnd-github.huawei.com/cloudfoundry/lattice/issues/6
Before fix:

```
# ltc create -h
OPTIONS:
..........
--instances "1"                          Number of application instances to spawn on launch
```

After fix:

```
# ltc create -h
OPTIONS:
..........
--instances, -i "1"                          Number of application instances to spawn on launch
```

Similarly for other options also

And i also found one difference in `ltc logs` command usage with respect to other commands . that also i have made changes.
Before fix:

```
# ltc logs
Incorrect Usage
```

After fix:

```
# ltc logs
Incorrect Usage: APP_NAME required
```

[#93138244]
