### PR TITLE
Requesting extra information for status command when we use -r and -s options.

### DIFF
--- a/ltc/app_examiner/command_factory/app_examiner_command_factory.go
+++ b/ltc/app_examiner/command_factory/app_examiner_command_factory.go
@@ -22,8 +22,7 @@ import (
 )
 
 const (
-	TimestampDisplayLayout = "2006-01-02 15:04:05 (MST)"
-	minColumnWidth         = 13
+	minColumnWidth = 13
 )
 
 var (
@@ -257,14 +256,14 @@ func (factory *AppExaminerCommandFactory) printInstanceSummary(actualInstances [
 	w := tabwriter.NewWriter(factory.ui, minColumnWidth, 8, 1, '\t', 0)
 
 	printHorizontalRule(w, "=")
-	fmt.Fprintf(w, fmt.Sprintf("%s\t%s\t%s\t%s\n", "Instance", colors.NoColor("State")+"    ", "Crashes", "Since"))
+	fmt.Fprintf(w, fmt.Sprintf("%s\t%s\t%s\t%s\t%s\t%s\n", "Instance", colors.NoColor("State")+"    ", "Crashes", "CPU", "Memory", "Since"))
 	printHorizontalRule(w, "-")
 
 	for _, instance := range actualInstances {
 		if instance.PlacementError == "" && instance.State != "CRASHED" {
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", strconv.Itoa(instance.Index), presentation.PadAndColorInstanceState(instance), strconv.Itoa(instance.CrashCount), fmt.Sprint(time.Unix(0, instance.Since).Format(TimestampDisplayLayout)))
+			fmt.Fprintf(w, "%s\t%s\t%s\t%.2f%%\t%s\t%s\n", strconv.Itoa(instance.Index), presentation.PadAndColorInstanceState(instance), strconv.Itoa(instance.CrashCount), (instance.Metrics.CpuPercentage), (bytefmt.ByteSize(instance.Metrics.MemoryBytes)), fmt.Sprint(time.Since(time.Unix(0, instance.Since)).String()))
 		} else {
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", strconv.Itoa(instance.Index), presentation.PadAndColorInstanceState(instance), strconv.Itoa(instance.CrashCount), "N/A")
+			fmt.Fprintf(w, "%s\t%s\t%s\t%.2f%%\t%s\t%s\n", strconv.Itoa(instance.Index), presentation.PadAndColorInstanceState(instance), strconv.Itoa(instance.CrashCount), (instance.Metrics.CpuPercentage), (bytefmt.ByteSize(instance.Metrics.MemoryBytes)), "N/A")
 		}
 	}
 
@@ -296,7 +295,7 @@ func (factory *AppExaminerCommandFactory) printInstanceInfo(actualInstances []ap
 			}
 			fmt.Fprintf(w, "%s\t%s\n", "Port Mapping", strings.Join(portMappingStrings, ";"))
 
-			fmt.Fprintf(w, "%s\t%s\n", "Since", fmt.Sprint(time.Unix(0, instance.Since).Format(TimestampDisplayLayout)))
+			fmt.Fprintf(w, "%s\t%s\n", "Since", fmt.Sprint(time.Since(time.Unix(0, instance.Since)).String()))
 
 		} else if instance.State != "CRASHED" {
 			fmt.Fprintf(w, "%s\t%s\n", "Placement Error", instance.PlacementError)
@@ -305,8 +304,8 @@ func (factory *AppExaminerCommandFactory) printInstanceInfo(actualInstances []ap
 		fmt.Fprintf(w, "%s \t%d \n", "Crash Count", instance.CrashCount)
 
 		if instance.HasMetrics {
-			fmt.Fprintf(w, "%s \t%.2f \n", "CPU Percentage", instance.Metrics.CpuPercentage)
-			fmt.Fprintf(w, "%s \t%s \n", "Memory Usage", bytefmt.ByteSize(instance.Metrics.MemoryBytes))
+			fmt.Fprintf(w, "%s \t%.2f%% \n", "CPU", instance.Metrics.CpuPercentage)
+			fmt.Fprintf(w, "%s \t%s \n", "Memory", bytefmt.ByteSize(instance.Metrics.MemoryBytes))
 		}
 		printHorizontalRule(w, "-")
 	}

--- a/ltc/app_examiner/command_factory/app_examiner_command_factory_test.go
+++ b/ltc/app_examiner/command_factory/app_examiner_command_factory_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -337,6 +338,11 @@ var _ = Describe("CommandFactory", func() {
 
 			test_helpers.ExecuteCommandWithArgs(statusCommand, []string{"wompy-app"})
 
+			/* Calculating the since time here to avoid comparing the different Since values. */
+			timeSince := time.Since(time.Unix(0, 401120627*1e9))
+			timeHours := fmt.Sprint(timeSince.Hours())
+			prettyTimestamp := strings.Split(timeHours, ".")[0]
+
 			Expect(appExaminer.AppStatusCallCount()).To(Equal(1))
 			Expect(appExaminer.AppStatusArgsForCall(0)).To(Equal("wompy-app"))
 
@@ -391,16 +397,15 @@ var _ = Describe("CommandFactory", func() {
 
 			Expect(outputBuffer).To(test_helpers.Say("Since"))
 
-			prettyTimestamp := time.Unix(0, 401120627*1e9).Format(command_factory.TimestampDisplayLayout)
 			Expect(outputBuffer).To(test_helpers.Say(prettyTimestamp))
 
 			Expect(outputBuffer).To(test_helpers.Say("Crash Count"))
 			Expect(outputBuffer).To(test_helpers.Say("0"))
 
-			Expect(outputBuffer).To(test_helpers.Say("CPU Percentage"))
-			Expect(outputBuffer).To(test_helpers.Say("23.46"))
+			Expect(outputBuffer).To(test_helpers.Say("CPU"))
+			Expect(outputBuffer).To(test_helpers.Say("23.46%"))
 
-			Expect(outputBuffer).To(test_helpers.Say("Memory Usage"))
+			Expect(outputBuffer).To(test_helpers.Say("Memory"))
 			Expect(outputBuffer).To(test_helpers.Say("640K"))
 
 			Expect(outputBuffer).To(test_helpers.Say("Instance 4"))
@@ -411,8 +416,8 @@ var _ = Describe("CommandFactory", func() {
 			Expect(outputBuffer).To(test_helpers.Say("insufficient resources."))
 			Expect(outputBuffer).To(test_helpers.Say("Crash Count"))
 			Expect(outputBuffer).To(test_helpers.Say("2"))
-			Expect(outputBuffer).NotTo(test_helpers.Say("CPU Percentage"))
-			Expect(outputBuffer).NotTo(test_helpers.Say("Memory Usage"))
+			Expect(outputBuffer).NotTo(test_helpers.Say("CPU"))
+			Expect(outputBuffer).NotTo(test_helpers.Say("Memory"))
 
 			Expect(outputBuffer).To(test_helpers.Say("Instance 5"))
 			Expect(outputBuffer).To(test_helpers.Say("CRASHED"))
@@ -421,8 +426,8 @@ var _ = Describe("CommandFactory", func() {
 			Expect(outputBuffer).To(test_helpers.Say("Crash Count"))
 			Expect(outputBuffer).To(test_helpers.Say("7"))
 
-			Expect(outputBuffer).NotTo(test_helpers.Say("CPU Percentage"))
-			Expect(outputBuffer).NotTo(test_helpers.Say("Memory Usage"))
+			Expect(outputBuffer).NotTo(test_helpers.Say("CPU"))
+			Expect(outputBuffer).NotTo(test_helpers.Say("Memory"))
 
 		})
 
@@ -462,23 +467,32 @@ var _ = Describe("CommandFactory", func() {
 
 				test_helpers.ExecuteCommandWithArgs(statusCommand, []string{"wompy-app", "--summary"})
 
+				timeSince := time.Since(time.Unix(0, 401120627*1e9))
+				timeHours := fmt.Sprint(timeSince.Hours())
+				prettyTimestamp := strings.Split(timeHours, ".")[0]
+
 				Expect(appExaminer.AppStatusCallCount()).To(Equal(1))
 				Expect(appExaminer.AppStatusArgsForCall(0)).To(Equal("wompy-app"))
 
 				Expect(outputBuffer).To(test_helpers.Say("Instance"))
 				Expect(outputBuffer).To(test_helpers.Say("State"))
 				Expect(outputBuffer).To(test_helpers.Say("Crashes"))
+				Expect(outputBuffer).To(test_helpers.Say("CPU"))
+				Expect(outputBuffer).To(test_helpers.Say("Memory"))
 				Expect(outputBuffer).To(test_helpers.Say("Since"))
 
 				Expect(outputBuffer).To(test_helpers.Say("3"))
 				Expect(outputBuffer).To(test_helpers.Say("RUNNING"))
 				Expect(outputBuffer).To(test_helpers.Say("0"))
-				prettyTimestamp := time.Unix(0, 401120627*1e9).Format(command_factory.TimestampDisplayLayout)
+				Expect(outputBuffer).To(test_helpers.Say("23.46%"))
+				Expect(outputBuffer).To(test_helpers.Say("640K"))
 				Expect(outputBuffer).To(test_helpers.Say(prettyTimestamp))
 
 				Expect(outputBuffer).To(test_helpers.Say("4"))
 				Expect(outputBuffer).To(test_helpers.Say("UNCLAIMED"))
 				Expect(outputBuffer).To(test_helpers.Say("2"))
+				Expect(outputBuffer).To(test_helpers.Say("0.00%"))
+				Expect(outputBuffer).To(test_helpers.Say("0"))
 
 				Expect(outputBuffer).To(test_helpers.Say("5"))
 				Expect(outputBuffer).To(test_helpers.Say("CRASHED"))
@@ -504,8 +518,11 @@ var _ = Describe("CommandFactory", func() {
 
 				closeChan = test_helpers.AsyncExecuteCommandWithArgs(statusCommand, []string{"wompy-app", "--rate", "2s"})
 
+				timeSince := time.Since(time.Unix(0, 401120627*1e9))
+				timeHours := fmt.Sprint(timeSince.Hours())
+				prettyTimestamp := strings.Split(timeHours, ".")[0]
+
 				Eventually(outputBuffer).Should(test_helpers.Say("wompy-app"))
-				prettyTimestamp := time.Unix(0, 401120627*1e9).Format(command_factory.TimestampDisplayLayout)
 				Eventually(outputBuffer).Should(test_helpers.Say(prettyTimestamp))
 
 				clock.IncrementBySeconds(1)
@@ -525,6 +542,10 @@ var _ = Describe("CommandFactory", func() {
 						},
 					},
 				}
+				timeSince = time.Since(time.Unix(0, 405234567*1e9))
+				timeHours = fmt.Sprint(timeSince.Hours())
+				prettyTimestamp = strings.Split(timeHours, ".")[0]
+
 				appExaminer.AppStatusReturns(refreshAppInfo, nil)
 
 				clock.IncrementBySeconds(1)
@@ -532,7 +553,7 @@ var _ = Describe("CommandFactory", func() {
 				Eventually(outputBuffer).Should(test_helpers.Say(cursor.Hide()))
 				Eventually(outputBuffer).Should(test_helpers.Say(cursor.Up(24)))
 				Eventually(outputBuffer).Should(test_helpers.Say("wompy-app"))
-				prettyTimestamp = time.Unix(0, 405234567*1e9).Format(command_factory.TimestampDisplayLayout)
+
 				Eventually(outputBuffer).Should(test_helpers.Say(prettyTimestamp))
 			})
 


### PR DESCRIPTION
We did the code changes as per the comments given in
https://github.com/cloudfoundry-incubator/lattice/issues/112
1. We coudn't able to do the time `1d15h27m` formate as per the comment using th `time.Since()`.

Current Output:

```
================================================================================
Instance        State           Crashes  Since
--------------------------------------------------------------------------------
0       RUNNING      0          2015-04-27 21:07:54 (EDT)
1       RUNNING      0          2015-04-27 22:06:12 (EDT)
2       RUNNING      0          2015-04-27 22:06:12 (EDT)
```

Requested Output:

```
================================================================================
Instance        State   Crashes         CPU             Memory     Since
--------------------------------------------------------------------------------
0       RUNNING      0          0.06%    820K           25h5m43.372958814s
1       RUNNING      0          0.07%    2.7M           25h5m16.860579569s
2       RUNNING      0          0.06%    2.7M           25h5m16.821532981s
```

Any other suggestions are welcome :)
