### PR TITLE
Implemented Themed help text-Part2 - Review Comment fix

### DIFF
--- a/ltc/cli_app_factory/app_help_test.go
+++ b/ltc/cli_app_factory/app_help_test.go
@@ -26,6 +26,11 @@ var _ = Describe("AppHelp", func() {
 		{{.Name}}
 		{{end}}{{end}}{{end}}`
 
+	subCommandTemplate := `NAME:
+   {{.Name}} - {{.Usage}}
+USAGE:
+   {{.Name}} command{{if .Flags}} [command options]{{end}} [arguments...]
+`
 	BeforeEach(func() {
 		outputBuffer = gbytes.NewBuffer()
 
@@ -55,4 +60,21 @@ var _ = Describe("AppHelp", func() {
 		}
 	})
 
+	Describe("commandPrintHelp", func() {
+		It("Shows help for particular command", func() {
+			commandRan := false
+			subCommand := cli.Command{
+				Name:        "print-a-command",
+				ShortName:   "p",
+				Description: "Print command",
+				Usage:       "print-a-command [arguments]",
+				Action:      func(ctx *cli.Context) { commandRan = true },
+			}
+
+			cli_app_factory.ShowHelp(outputBuffer, subCommandTemplate, subCommand)
+			outputBytes, err := ioutil.ReadAll(outputBuffer)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(outputBytes)).To(ContainSubstring(subCommand.Name))
+		})
+	})
 })

--- a/ltc/cli_app_factory/cli_app_factory.go
+++ b/ltc/cli_app_factory/cli_app_factory.go
@@ -56,7 +56,7 @@ const (
 	AppName           = "ltc"
 	latticeCliAuthor  = "Pivotal"
 	latticeCliHomeVar = "LATTICE_CLI_HOME"
-	unknownCommand    = "ltc: '%s' is not a registered command. See 'ltc help'"
+	unknownCommand    = "ltc: '%s' is not a registered command. See 'ltc help'\n\n"
 )
 
 func MakeCliApp(latticeVersion, ltcConfigRoot string, exitHandler exit_handler.ExitHandler, config *config.Config, logger lager.Logger, targetVerifier target_verifier.TargetVerifier, cliStdout io.Writer) *cli.App {
@@ -94,7 +94,8 @@ func MakeCliApp(latticeVersion, ltcConfigRoot string, exitHandler exit_handler.E
 
 	app.Action = defaultAction
 	app.CommandNotFound = func(c *cli.Context, command string) {
-		fmt.Println(fmt.Sprintf(unknownCommand, command))
+		ui.Say(fmt.Sprintf(unknownCommand, command))
+		os.Exit(1)
 	}
 	cli.AppHelpTemplate = appHelpTemplate()
 	cli.HelpPrinter = ShowHelp

--- a/ltc/integration_test/integration_test_runner.go
+++ b/ltc/integration_test/integration_test_runner.go
@@ -282,7 +282,7 @@ func defineTheMainTests(runner *integrationTestRunner) {
 			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(session, 3*time.Second).Should(gbytes.Say("not a registered command"))
-			Eventually(session).Should(gexec.Exit(0))
+			Eventually(session).Should(gexec.Exit(1))
 		})
 
 		It("exits non-zero when known command is invoked with invalid option", func() {
@@ -290,84 +290,6 @@ func defineTheMainTests(runner *integrationTestRunner) {
 			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(session, 3*time.Second).Should(gexec.Exit(1))
-		})
-	})
-
-	Describe("Flag verification", func() {
-		It("informs user for any incorrect provided flags", func() {
-			command := runner.command("create", "--instances", "--bad-flag")
-			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
-			Expect(err).ToNot(HaveOccurred())
-			Eventually(session.Out).Should(gbytes.Say("\"--bad-flag\""))
-			Consistently(session.Out).ShouldNot(gbytes.Say("\"--instances\""))
-		})
-
-		It("checks flags with prefix '--'", func() {
-			command := runner.command("create", "not-a-flag", "--invalid-flag")
-			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
-			Expect(err).ToNot(HaveOccurred())
-			Eventually(session.Out).Should(gbytes.Say("Unknown flag \"--invalid-flag\""))
-			Consistently(session.Out).ShouldNot(gbytes.Say("Unknown flag \"not-a-flag\""))
-		})
-
-		It("checks flags with prefix '-'", func() {
-			command := runner.command("create", "not-a-flag", "-invalid-flag")
-			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
-			Expect(err).ToNot(HaveOccurred())
-			Eventually(session.Out).Should(gbytes.Say("\"-invalid-flag\""))
-			Consistently(session.Out).ShouldNot(gbytes.Say("\"not-a-flag\""))
-		})
-
-		It("checks flags but ignores the value after '=' ", func() {
-			command := runner.command("create", "-i=1", "-invalid-flag=blarg")
-			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
-			Expect(err).ToNot(HaveOccurred())
-			Eventually(session.Out).Should(gbytes.Say("\"-invalid-flag\""))
-			Consistently(session.Out).ShouldNot(gbytes.Say("Unknown flag \"-p\""))
-		})
-
-		It("outputs all unknown flags in single sentence", func() {
-			command := runner.command("create", "--bad-flag1", "--bad-flag2", "--bad-flag3")
-			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
-			Expect(err).ToNot(HaveOccurred())
-			Eventually(session.Out).Should(gbytes.Say("\"--bad-flag1\", \"--bad-flag2\", \"--bad-flag3\""))
-		})
-
-		It("only checks input flags against flags from the provided command", func() {
-			command := runner.command("create", "--instances", "--skip-ssl-validation")
-			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
-			Expect(err).ToNot(HaveOccurred())
-			Eventually(session.Out).Should(gbytes.Say("\"--skip-ssl-validation\""))
-		})
-
-		It("accepts -h and --h flags for all commands", func() {
-			command := runner.command("create", "-h")
-			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
-			Expect(err).ToNot(HaveOccurred())
-			Consistently(session.Out).ShouldNot(gbytes.Say("Unknown flag \"-h\""))
-			command = runner.command("target", "--h")
-			session, err = gexec.Start(command, GinkgoWriter, GinkgoWriter)
-			Expect(err).ToNot(HaveOccurred())
-			Consistently(session.Out).ShouldNot(gbytes.Say("Unknown flag \"--h\""))
-		})
-
-		Context("When a negative integer is preceeded by a valid flag", func() {
-			It("skips validation for negative integer flag values", func() {
-				command := runner.command("create", "-i", "-10")
-				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
-				Expect(err).ToNot(HaveOccurred())
-				Eventually(session.Out).ShouldNot(gbytes.Say("\"-10\""))
-			})
-		})
-
-		Context("When a negative integer is preceeded by a invalid flag", func() {
-			It("validates the negative integer as a flag", func() {
-				command := runner.command("create", "-badflag", "-10")
-				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
-				Expect(err).ToNot(HaveOccurred())
-				Eventually(session.Out).Should(gbytes.Say("\"-badflag\""))
-				Eventually(session.Out).Should(gbytes.Say("\"-10\""))
-			})
 		})
 	})
 }

--- a/ltc/main.go
+++ b/ltc/main.go
@@ -1,150 +1,29 @@
 package main
 
 import (
-	"errors"
-	"fmt"
 	"os"
-	"strconv"
-	"strings"
 
 	"github.com/cloudfoundry-incubator/lattice/ltc/setup_cli"
-	"github.com/codegangsta/cli"
 )
 
 func main() {
 	defer os.Stdout.Write([]byte("\n"))
 	var badFlags string
 	cliApp := setup_cli.NewCliApp()
+
 	if len(os.Args) > 1 {
-		flags := GetCommandFlags(cliApp, os.Args[1])
-		badFlags = matchArgAndFlags(flags, os.Args[2:])
+		flags := setup_cli.GetCommandFlags(cliApp, os.Args[1])
+		badFlags = setup_cli.MatchArgAndFlags(flags, os.Args[2:])
 		if badFlags != "" {
 			badFlags = badFlags + "\n\n"
 		}
 	}
-	injectHelpTemplate(badFlags)
-	if len(os.Args) == 1 || os.Args[1] == "help" || os.Args[1] == "h" || requestHelp(os.Args[1:]) {
+
+	setup_cli.InjectHelpTemplate(badFlags)
+
+	if len(os.Args) == 1 || os.Args[1] == "help" || os.Args[1] == "h" || setup_cli.RequestHelp(os.Args[1:]) {
 		cliApp.Run(os.Args)
 	} else {
-		callCoreCommand(os.Args[0:], cliApp)
+		setup_cli.CallCoreCommand(os.Args[0:], cliApp)
 	}
-}
-
-func injectHelpTemplate(badFlags string) {
-	cli.CommandHelpTemplate = fmt.Sprintf(`%sNAME:
-   {{join .Names ", "}} - {{.Usage}}
-{{with .ShortName}}
-ALIAS:
-   {{.Aliases}}
-{{end}}
-USAGE:
-   {{.Description}}{{with .Flags}}
-OPTIONS:
-{{range .}}   {{.}}
-{{end}}{{else}}
-{{end}}`, badFlags)
-}
-
-func matchArgAndFlags(flags []string, args []string) string {
-	var badFlag string
-	var lastPassed bool
-	multipleFlagErr := false
-Loop:
-	for _, arg := range args {
-		prefix := ""
-		//only take flag name, ignore value after '='
-		arg = strings.Split(arg, "=")[0]
-		if arg == "--h" || arg == "-h" || arg == "--help" || arg == "-help" {
-			continue Loop
-		}
-		if strings.HasPrefix(arg, "--") {
-			prefix = "--"
-		} else if strings.HasPrefix(arg, "-") {
-			prefix = "-"
-		}
-		arg = strings.TrimLeft(arg, prefix)
-		//skip verification for negative integers, e.g. -i -10
-		if lastPassed {
-			lastPassed = false
-			if _, err := strconv.ParseInt(arg, 10, 32); err == nil {
-				continue Loop
-			}
-		}
-		if prefix != "" {
-			for _, flag := range flags {
-				for _, f := range strings.Split(flag, ", ") {
-					flag = strings.TrimSpace(f)
-					if flag == arg {
-						lastPassed = true
-						continue Loop
-					}
-				}
-			}
-			if badFlag == "" {
-				badFlag = fmt.Sprintf("\"%s%s\"", prefix, arg)
-			} else {
-				multipleFlagErr = true
-				badFlag = badFlag + fmt.Sprintf(", \"%s%s\"", prefix, arg)
-			}
-		}
-	}
-	if multipleFlagErr && badFlag != "" {
-		badFlag = fmt.Sprintf("%s %s", "Unknown flags:", badFlag)
-	} else if badFlag != "" {
-		badFlag = fmt.Sprintf("%s %s", "Unknown flag", badFlag)
-	}
-	return badFlag
-}
-
-func requestHelp(args []string) bool {
-	for _, v := range args {
-		if v == "-h" || v == "--help" {
-			return true
-		}
-	}
-	return false
-}
-
-func callCoreCommand(args []string, cliApp *cli.App) {
-	err := cliApp.Run(args)
-	if err != nil {
-		os.Exit(1)
-	}
-}
-
-func GetCommandFlags(app *cli.App, command string) []string {
-	cmd, err := GetByCmdName(app, command)
-	if err != nil {
-		return []string{}
-	}
-	var flags []string
-	for _, flag := range cmd.Flags {
-		switch t := flag.(type) {
-		default:
-		case cli.StringSliceFlag:
-			flags = append(flags, t.Name)
-		case cli.IntFlag:
-			flags = append(flags, t.Name)
-		case cli.StringFlag:
-			flags = append(flags, t.Name)
-		case cli.BoolFlag:
-			flags = append(flags, t.Name)
-		case cli.DurationFlag:
-			flags = append(flags, t.Name)
-		}
-	}
-	return flags
-}
-
-func GetByCmdName(app *cli.App, cmdName string) (cmd *cli.Command, err error) {
-	cmd = app.Command(cmdName)
-	if cmd == nil {
-		for _, c := range app.Commands {
-			if c.ShortName == cmdName {
-				return &c, nil
-			}
-		}
-		err = errors.New("Command not found")
-	}
-	return
 }

--- a/ltc/setup_cli/help_helpers.go
+++ b/ltc/setup_cli/help_helpers.go
@@ -1,0 +1,130 @@
+package setup_cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/codegangsta/cli"
+)
+
+func InjectHelpTemplate(badFlags string) {
+	cli.CommandHelpTemplate = fmt.Sprintf(`%sNAME:
+   {{join .Names ", "}} - {{.Usage}}
+{{with .ShortName}}
+ALIAS:
+   {{.Aliases}}
+{{end}}
+USAGE:
+   {{.Description}}{{with .Flags}}
+OPTIONS:
+{{range .}}   {{.}}
+{{end}}{{else}}
+{{end}}`, badFlags)
+}
+
+func MatchArgAndFlags(flags []string, args []string) string {
+	var badFlag string
+	var lastPassed bool
+	multipleFlagErr := false
+Loop:
+	for _, arg := range args {
+		prefix := ""
+		//only take flag name, ignore value after '='
+		arg = strings.Split(arg, "=")[0]
+		if arg == "--h" || arg == "-h" || arg == "--help" || arg == "-help" {
+			continue Loop
+		}
+		if strings.HasPrefix(arg, "--") {
+			prefix = "--"
+		} else if strings.HasPrefix(arg, "-") {
+			prefix = "-"
+		}
+		arg = strings.TrimLeft(arg, prefix)
+		//skip verification for negative integers, e.g. -i -10
+		if lastPassed {
+			lastPassed = false
+			if _, err := strconv.ParseInt(arg, 10, 32); err == nil {
+				continue Loop
+			}
+		}
+		if prefix != "" {
+			for _, flag := range flags {
+				for _, f := range strings.Split(flag, ", ") {
+					flag = strings.TrimSpace(f)
+					if flag == arg {
+						lastPassed = true
+						continue Loop
+					}
+				}
+			}
+			if badFlag == "" {
+				badFlag = fmt.Sprintf("\"%s%s\"", prefix, arg)
+			} else {
+				multipleFlagErr = true
+				badFlag = badFlag + fmt.Sprintf(", \"%s%s\"", prefix, arg)
+			}
+		}
+	}
+	if multipleFlagErr && badFlag != "" {
+		badFlag = fmt.Sprintf("%s %s", "Unknown flags:", badFlag)
+	} else if badFlag != "" {
+		badFlag = fmt.Sprintf("%s %s", "Unknown flag", badFlag)
+	}
+	return badFlag
+}
+
+func RequestHelp(args []string) bool {
+	for _, v := range args {
+		if v == "-h" || v == "--help" {
+			return true
+		}
+	}
+	return false
+}
+
+func CallCoreCommand(args []string, cliApp *cli.App) {
+	err := cliApp.Run(args)
+	if err != nil {
+		os.Exit(1)
+	}
+}
+
+func GetCommandFlags(app *cli.App, command string) []string {
+	cmd, err := GetByCmdName(app, command)
+	if err != nil {
+		return []string{}
+	}
+	var flags []string
+	for _, flag := range cmd.Flags {
+		switch t := flag.(type) {
+		default:
+		case cli.StringSliceFlag:
+			flags = append(flags, t.Name)
+		case cli.IntFlag:
+			flags = append(flags, t.Name)
+		case cli.StringFlag:
+			flags = append(flags, t.Name)
+		case cli.BoolFlag:
+			flags = append(flags, t.Name)
+		case cli.DurationFlag:
+			flags = append(flags, t.Name)
+		}
+	}
+	return flags
+}
+
+func GetByCmdName(app *cli.App, cmdName string) (cmd *cli.Command, err error) {
+	cmd = app.Command(cmdName)
+	if cmd == nil {
+		for _, c := range app.Commands {
+			if c.ShortName == cmdName {
+				return &c, nil
+			}
+		}
+		err = errors.New("Command not found")
+	}
+	return
+}

--- a/ltc/setup_cli/help_helpers_test.go
+++ b/ltc/setup_cli/help_helpers_test.go
@@ -1,0 +1,313 @@
+package setup_cli_test
+
+import (
+	. "github.com/cloudfoundry-incubator/lattice/ltc/setup_cli"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/cloudfoundry-incubator/lattice/ltc/cli_app_factory"
+	"github.com/cloudfoundry-incubator/lattice/ltc/config"
+	"github.com/cloudfoundry-incubator/lattice/ltc/config/persister"
+	"github.com/cloudfoundry-incubator/lattice/ltc/config/target_verifier/fake_target_verifier"
+	"github.com/cloudfoundry-incubator/lattice/ltc/exit_handler/fake_exit_handler"
+	"github.com/cloudfoundry-incubator/lattice/ltc/terminal"
+	"github.com/cloudfoundry-incubator/lattice/ltc/test_helpers"
+	"github.com/codegangsta/cli"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/pivotal-golang/lager"
+)
+
+var _ = Describe("HelpHelpers", func() {
+	var (
+		fakeTargetVerifier *fake_target_verifier.FakeTargetVerifier
+		memPersister       persister.Persister
+		outputBuffer       *gbytes.Buffer
+		terminalUI         terminal.UI
+		cliApp             *cli.App
+		cliConfig          *config.Config
+		latticeVersion     string
+	)
+
+	BeforeEach(func() {
+		fakeTargetVerifier = &fake_target_verifier.FakeTargetVerifier{}
+		memPersister = persister.NewMemPersister()
+		outputBuffer = gbytes.NewBuffer()
+		terminalUI = terminal.NewUI(nil, outputBuffer, nil)
+		cliConfig = config.New(memPersister)
+		latticeVersion = "v0.2.Test"
+		cliApp = cli_app_factory.MakeCliApp(
+			latticeVersion,
+			"~/",
+			&fake_exit_handler.FakeExitHandler{},
+			cliConfig,
+			lager.NewLogger("test"),
+			fakeTargetVerifier,
+			terminalUI,
+		)
+		cliApp.Writer = terminalUI
+	})
+
+	Describe("MatchArgAndFlags", func() {
+		It("Checks for badflag", func() {
+			cliAppArgs := []string{"ltc", "create", "--badflag"}
+			flags := GetCommandFlags(cliApp, cliAppArgs[1])
+			badFlags := MatchArgAndFlags(flags, cliAppArgs[2:])
+
+			Expect(badFlags).To(Equal("Unknown flag \"--badflag\""))
+
+		})
+
+		It("returns if multiple bad flags are passed", func() {
+			cliAppArgs := []string{"ltc", "create", "--badflag1", "--badflag2"}
+			flags := GetCommandFlags(cliApp, cliAppArgs[1])
+			badFlags := MatchArgAndFlags(flags, cliAppArgs[2:])
+			InjectHelpTemplate(badFlags)
+			Expect(badFlags).To(Equal("Unknown flags: \"--badflag1\", \"--badflag2\""))
+
+		})
+	})
+
+	Describe("GetCommandFlags", func() {
+		It("returns list of type Flag", func() {
+			flaglist := GetCommandFlags(cliApp, "create")
+			cmd := cliApp.Command("create")
+			for _, flag := range cmd.Flags {
+				switch t := flag.(type) {
+				default:
+				case cli.StringSliceFlag:
+					Expect(flaglist).Should(ContainElement(t.Name))
+				case cli.IntFlag:
+					Expect(flaglist).Should(ContainElement(t.Name))
+				case cli.StringFlag:
+					Expect(flaglist).Should(ContainElement(t.Name))
+				case cli.BoolFlag:
+					Expect(flaglist).Should(ContainElement(t.Name))
+				case cli.DurationFlag:
+					Expect(flaglist).Should(ContainElement(t.Name))
+				}
+			}
+		})
+	})
+
+	Describe("GetByCmdName", func() {
+		It("returns command not found error", func() {
+			_, err := GetByCmdName(cliApp, "zz")
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError("Command not found"))
+
+		})
+	})
+
+	Describe("RequestHelp", func() {
+		It("checks for the flag -h", func() {
+			cliAppArgs := []string{"ltc", "-h"}
+			boolVal := RequestHelp(cliAppArgs[1:])
+			Expect(boolVal).To(BeTrue())
+		})
+
+		It("checks for the flag --help", func() {
+			cliAppArgs := []string{"ltc", "--help"}
+			boolVal := RequestHelp(cliAppArgs[1:])
+			Expect(boolVal).To(BeTrue())
+		})
+
+		It("checks for the unknown flag", func() {
+			cliAppArgs := []string{"ltc", "--unknownFlag"}
+			boolVal := RequestHelp(cliAppArgs[1:])
+			Expect(boolVal).To(BeFalse())
+		})
+
+	})
+
+	Describe("Flag verification", func() {
+
+		BeforeEach(func() {
+			commandRan := false
+			cliApp.Commands = []cli.Command{
+				cli.Command{Name: "print-a-unicorn",
+					Action: func(ctx *cli.Context) { commandRan = true },
+					Flags: []cli.Flag{
+						cli.IntFlag{
+							Name:  "flag1, f1",
+							Usage: "flag for print-a-unicorn command",
+							Value: 10,
+						},
+						cli.BoolFlag{
+							Name:  "flag2, f2",
+							Usage: "flag for print-a-unicorn command",
+						},
+					},
+				},
+			}
+
+		})
+
+		It("informs user for any incorrect provided flags", func() {
+			fakeTargetVerifier.VerifyTargetReturns(true, true, nil)
+
+			cliConfig.SetTarget("my-lattice.example.com")
+			cliConfig.Save()
+
+			cliAppArgs := []string{"ltc", "print-a-unicorn", "--bad-flag=10"}
+			flags := GetCommandFlags(cliApp, cliAppArgs[1])
+			badFlags := MatchArgAndFlags(flags, cliAppArgs[2:])
+			InjectHelpTemplate(badFlags)
+			err := cliApp.Run(cliAppArgs)
+			Expect(err).To(HaveOccurred())
+
+			Expect(outputBuffer).To(test_helpers.Say("Incorrect Usage."))
+			Expect(outputBuffer).To(test_helpers.Say("Unknown flag \"--bad-flag\""))
+
+		})
+
+		It("checks flags with prefix '--'", func() {
+			fakeTargetVerifier.VerifyTargetReturns(true, true, nil)
+
+			cliConfig.SetTarget("my-lattice.example.com")
+			cliConfig.Save()
+
+			cliAppArgs := []string{"ltc", "print-a-unicorn", "not-a-flag", "--invalid-flag"}
+			flags := GetCommandFlags(cliApp, cliAppArgs[1])
+			badFlags := MatchArgAndFlags(flags, cliAppArgs[2:])
+			InjectHelpTemplate(badFlags)
+			err := cliApp.Run(cliAppArgs)
+			Expect(err).To(HaveOccurred())
+
+			Expect(outputBuffer).To(test_helpers.Say("Incorrect Usage."))
+			Expect(outputBuffer).To(test_helpers.Say("Unknown flag \"--invalid-flag\""))
+			Expect(outputBuffer).NotTo(test_helpers.Say("Unknown flag \"not-a-flag\""))
+
+		})
+
+		It("checks flags with prefix '-'", func() {
+			fakeTargetVerifier.VerifyTargetReturns(true, true, nil)
+
+			cliConfig.SetTarget("my-lattice.example.com")
+			cliConfig.Save()
+
+			cliAppArgs := []string{"ltc", "print-a-unicorn", "not-a-flag", "-invalid-flag"}
+			flags := GetCommandFlags(cliApp, cliAppArgs[1])
+			badFlags := MatchArgAndFlags(flags, cliAppArgs[2:])
+			InjectHelpTemplate(badFlags)
+			err := cliApp.Run(cliAppArgs)
+			Expect(err).To(HaveOccurred())
+
+			Expect(outputBuffer).To(test_helpers.Say("Incorrect Usage."))
+			Expect(outputBuffer).To(test_helpers.Say("\"-invalid-flag\""))
+			Expect(outputBuffer).NotTo(test_helpers.Say("\"not-a-flag\""))
+		})
+
+		It("checks flags but ignores the value after '=' ", func() {
+			fakeTargetVerifier.VerifyTargetReturns(true, true, nil)
+
+			cliConfig.SetTarget("my-lattice.example.com")
+			cliConfig.Save()
+
+			cliAppArgs := []string{"ltc", "print-a-unicorn", "-f1=1", "-invalid-flag=blarg"}
+			flags := GetCommandFlags(cliApp, cliAppArgs[1])
+			badFlags := MatchArgAndFlags(flags, cliAppArgs[2:])
+			InjectHelpTemplate(badFlags)
+			err := cliApp.Run(cliAppArgs)
+			Expect(err).To(HaveOccurred())
+
+			Expect(outputBuffer).To(test_helpers.Say("Incorrect Usage."))
+			Expect(outputBuffer).To(test_helpers.Say("\"-invalid-flag\""))
+			Expect(outputBuffer).NotTo(test_helpers.Say("Unknown flag \"-p\""))
+		})
+
+		It("outputs all unknown flags in single sentence", func() {
+			fakeTargetVerifier.VerifyTargetReturns(true, true, nil)
+
+			cliConfig.SetTarget("my-lattice.example.com")
+			cliConfig.Save()
+
+			cliAppArgs := []string{"ltc", "print-a-unicorn", "--bad-flag1", "--bad-flag2", "--bad-flag3"}
+			flags := GetCommandFlags(cliApp, cliAppArgs[1])
+			badFlags := MatchArgAndFlags(flags, cliAppArgs[2:])
+			InjectHelpTemplate(badFlags)
+			err := cliApp.Run(cliAppArgs)
+			Expect(err).To(HaveOccurred())
+
+			Expect(outputBuffer).To(test_helpers.Say("Incorrect Usage."))
+			Expect(outputBuffer).To(test_helpers.Say("\"--bad-flag1\", \"--bad-flag2\", \"--bad-flag3\""))
+		})
+
+		It("only checks input flags against flags from the provided command", func() {
+			fakeTargetVerifier.VerifyTargetReturns(true, true, nil)
+
+			cliConfig.SetTarget("my-lattice.example.com")
+			cliConfig.Save()
+
+			cliAppArgs := []string{"ltc", "print-a-unicorn", "--instances", "--skip-ssl-validation"}
+			flags := GetCommandFlags(cliApp, cliAppArgs[1])
+			badFlags := MatchArgAndFlags(flags, cliAppArgs[2:])
+			InjectHelpTemplate(badFlags)
+			err := cliApp.Run(cliAppArgs)
+			Expect(err).To(HaveOccurred())
+
+			Expect(outputBuffer).To(test_helpers.Say("Incorrect Usage."))
+			Expect(outputBuffer).To(test_helpers.Say("\"--skip-ssl-validation\""))
+		})
+
+		It("accepts -h and --h flags for all commands", func() {
+			fakeTargetVerifier.VerifyTargetReturns(true, true, nil)
+
+			cliConfig.SetTarget("my-lattice.example.com")
+			cliConfig.Save()
+
+			cliAppArgs := []string{"ltc", "print-a-unicorn", "-h"}
+			flags := GetCommandFlags(cliApp, cliAppArgs[1])
+			badFlags := MatchArgAndFlags(flags, cliAppArgs[2:])
+			InjectHelpTemplate(badFlags)
+			err := cliApp.Run(cliAppArgs)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(outputBuffer).NotTo(test_helpers.Say("Unknown flag \"-h\""))
+
+			cliAppArgs = []string{"ltc", "print-a-unicorn", "--h"}
+			flags = GetCommandFlags(cliApp, cliAppArgs[1])
+			badFlags = MatchArgAndFlags(flags, cliAppArgs[2:])
+			InjectHelpTemplate(badFlags)
+			err = cliApp.Run(cliAppArgs)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(outputBuffer).NotTo(test_helpers.Say("Unknown flag \"--h\""))
+		})
+
+		Context("When a negative integer is preceeded by a valid flag", func() {
+			It("skips validation for negative integer flag values", func() {
+				fakeTargetVerifier.VerifyTargetReturns(true, true, nil)
+				cliConfig.SetTarget("my-lattice.example.com")
+				cliConfig.Save()
+
+				cliAppArgs := []string{"ltc", "print-a-unicorn", "-f1", "-10"}
+				flags := GetCommandFlags(cliApp, cliAppArgs[1])
+				badFlags := MatchArgAndFlags(flags, cliAppArgs[2:])
+				InjectHelpTemplate(badFlags)
+				err := cliApp.Run(cliAppArgs)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(outputBuffer).NotTo(test_helpers.Say("\"-10\""))
+			})
+		})
+
+		Context("When a negative integer is preceeded by a invalid flag", func() {
+			It("validates the negative integer as a flag", func() {
+				fakeTargetVerifier.VerifyTargetReturns(true, true, nil)
+
+				cliConfig.SetTarget("my-lattice.example.com")
+				cliConfig.Save()
+
+				cliAppArgs := []string{"ltc", "print-a-unicorn", "-badflag", "-10"}
+				flags := GetCommandFlags(cliApp, cliAppArgs[1])
+				badFlags := MatchArgAndFlags(flags, cliAppArgs[2:])
+				InjectHelpTemplate(badFlags)
+				err := cliApp.Run(cliAppArgs)
+
+				Expect(err).To(HaveOccurred())
+				Expect(outputBuffer).To(test_helpers.Say("\"-badflag\""))
+				Expect(outputBuffer).To(test_helpers.Say("\"-10\""))
+			})
+		})
+	})
+})

--- a/ltc/setup_cli/setup_cli_suite_test.go
+++ b/ltc/setup_cli/setup_cli_suite_test.go
@@ -1,0 +1,13 @@
+package setup_cli_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestSetupCli(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "SetupCli Suite")
+}

--- a/ltc/setup_cli/setup_cli_test.go
+++ b/ltc/setup_cli/setup_cli_test.go
@@ -1,0 +1,26 @@
+package setup_cli_test
+
+import (
+	. "github.com/cloudfoundry-incubator/lattice/ltc/setup_cli"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/codegangsta/cli"
+)
+
+var _ = Describe("SetupCli", func() {
+
+	var (
+		cliApp *cli.App
+	)
+
+	Describe("NewCliApp", func() {
+		It("Runs registered command without error", func() {
+
+			cliApp = NewCliApp()
+
+			Expect(cliApp).NotTo(BeNil())
+		})
+	})
+})


### PR DESCRIPTION
Moved logic implemented in the main.go file to setup_cli/help_helpers.go and we changed CLI tests in the  integration_test_runner.go to unit tests(setup_cli/help_helpers_test.go) as suggested by Davidwadden. https://github.com/cloudfoundry-incubator/lattice/pull/119

In the current implementation when unknown command is invoked then its exiting with 0. To handle this we have added the following code. 
https://github.com/HuaweiTech/lattice/blob/hwcf-issue-12/ltc/cli_app_factory/cli_app_factory.go#L98

Is this OK or this scenario have to be handled using panic?

@dhilipkumars 
